### PR TITLE
add import: htmlwidgets

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,6 +8,8 @@ License: GPL-3 + file LICENSE
 LazyData: true
 URL: https://github.com/timelyportfolio/sankeytree
 BugReports: https://github.com/timelyportfolio/sankeytree/issues
+Imports:
+ htmlwidgets 
 Suggests: 
-    testthat
+ testthat
 RoxygenNote: 7.1.1


### PR DESCRIPTION
Currently fails to build in NixR as `htmlwidgets` is imported, but not listed as an import in the `DESCRIPTION` file.

Failing build:
https://github.com/Displayr/NixR/actions/runs/14301160732/job/40075752206#step:4:51

I think this might be because it is referenced in R code, like here:
https://github.com/Displayr/rhtmlSankeyTree/blob/54f18e921af8a9667f5425e0a23b399e01bc866c/R/rhtmlSankeyTree.R#L53